### PR TITLE
Change .NET Framework minimum version to 4.6.1.

### DIFF
--- a/VersionHistory.md
+++ b/VersionHistory.md
@@ -8,6 +8,7 @@ is updated in preparation for publishing an updated NuGet package.
 Prefix the description of the change with `[major]`, `[minor]` or `[patch]` in accordance with [SemVer](http://semver.org).
 
 * [minor] Add `ByteUtility`.
+* Change .NET Framework minimum version to 4.6.1.
 
 ## Released
 

--- a/build.cake
+++ b/build.cake
@@ -10,7 +10,7 @@ var versionSuffix = Argument("versionSuffix", "");
 
 var nugetSource = "https://api.nuget.org/v3/index.json";
 var solutionFileName = "Faithlife.Utility.sln";
-var docsAssembly = File($"src/Faithlife.Utility/bin/{configuration}/net46/Faithlife.Utility.dll").ToString();
+var docsAssembly = File($"src/Faithlife.Utility/bin/{configuration}/net461/Faithlife.Utility.dll").ToString();
 var docsSourceUri = "https://github.com/Faithlife/FaithlifeUtility/tree/master/src/Faithlife.Utility";
 
 Task("Clean")

--- a/src/Faithlife.Utility/Faithlife.Utility.csproj
+++ b/src/Faithlife.Utility/Faithlife.Utility.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <VersionPrefix>0.3.0</VersionPrefix>
-    <TargetFrameworks>netstandard1.4;netstandard2.0;net46</TargetFrameworks>
-    <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net46' and '$(MONO_ROOT)' != ''">$(MONO_ROOT)/lib/mono/4.6-api/</FrameworkPathOverride>
+    <TargetFrameworks>netstandard1.4;netstandard2.0;net461</TargetFrameworks>
+    <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net461' and '$(MONO_ROOT)' != ''">$(MONO_ROOT)/lib/mono/4.6.1-api/</FrameworkPathOverride>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
@@ -28,7 +28,7 @@
     <PackageReference Include="JetBrains.Annotations" Version="10.4.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.4' OR '$(TargetFramework)' == 'net46' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.4' OR '$(TargetFramework)' == 'net461' ">
     <PackageReference Include="System.ValueTuple" Version="4.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
`net461` is compatible with `netstandard1.4`, providing a consistent baseline API.