### PR TITLE
Fix TruncatedStream.CopyToAsync().

### DIFF
--- a/VersionHistory.md
+++ b/VersionHistory.md
@@ -7,7 +7,8 @@ is updated in preparation for publishing an updated NuGet package.
 
 Prefix the description of the change with `[major]`, `[minor]` or `[patch]` in accordance with [SemVer](http://semver.org).
 
-* [patch] Remove WrappingStream.CopyToAsync() override. Fixes TruncatedStream.CopyToAsync().
+* [major] Seal `WrappingStream`.
+* [major] Introduce `WrappingStreamBase` and make it the base class of `CachingStream`, `ReadOnlyStream`, `RebasedStream`, and `TruncatedStream`. This fixes `CopyToAsync` for `RebasedStream` and `TruncatedStream`.
 
 ## Released
 

--- a/VersionHistory.md
+++ b/VersionHistory.md
@@ -7,6 +7,8 @@ is updated in preparation for publishing an updated NuGet package.
 
 Prefix the description of the change with `[major]`, `[minor]` or `[patch]` in accordance with [SemVer](http://semver.org).
 
+* [patch] Remove WrappingStream.CopyToAsync() override. Fixes TruncatedStream.CopyToAsync().
+
 ## Released
 
 ### 0.4.2

--- a/src/Faithlife.Utility/CachingStream.cs
+++ b/src/Faithlife.Utility/CachingStream.cs
@@ -141,6 +141,11 @@ namespace Faithlife.Utility
 		/// </summary>
 		public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
 
+		/// <summary>
+		/// Asynchronously writes a sequence of bytes to the current stream, advances the current position within this stream by the number of bytes written, and monitors cancellation requests.
+		/// </summary>
+		public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => throw new NotSupportedException();
+
 		private byte[] LoadData(int blockIndex)
 		{
 			ThrowIfDisposed();

--- a/src/Faithlife.Utility/CachingStream.cs
+++ b/src/Faithlife.Utility/CachingStream.cs
@@ -5,10 +5,10 @@ using System.IO;
 namespace Faithlife.Utility
 {
 	/// <summary>
-	/// A <see cref="WrappingStream"/> that caches all data read from the underlying <see cref="Stream"/>.
+	/// A stream wrapper that caches all data read from the underlying <see cref="Stream"/>.
 	/// </summary>
 	/// <remarks>This implementation doesn't enforce any upper bound on the amount of data that will be cached in memory.</remarks>
-	public sealed class CachingStream : WrappingStream
+	public sealed class CachingStream : WrappingStreamBase
 	{
 		/// <summary>
 		/// Initializes a new instance of the <see cref="CachingStream"/> class.
@@ -123,23 +123,6 @@ namespace Faithlife.Utility
 		/// within this stream by the number of bytes written.
 		/// </summary>
 		public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
-
-		/// <summary>
-		/// Writes a byte to the current position in the stream and advances the position within the stream by one byte.
-		/// </summary>
-		public override void WriteByte(byte value) => throw new NotSupportedException();
-
-#if !NETSTANDARD1_4
-		/// <summary>
-		/// Begins an asynchronous write operation.
-		/// </summary>
-		public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state) => throw new NotSupportedException();
-
-		/// <summary>
-		/// Waits for the pending asynchronous read to complete.
-		/// </summary>
-		public override void EndWrite(IAsyncResult asyncResult) => throw new NotSupportedException();
-#endif
 
 		private byte[] LoadData(int blockIndex)
 		{

--- a/src/Faithlife.Utility/CachingStream.cs
+++ b/src/Faithlife.Utility/CachingStream.cs
@@ -182,6 +182,7 @@ namespace Faithlife.Utility
 
 			return blockData;
 		}
+
 		const int c_blockSize = 4096;
 
 		List<byte[]> m_blocks;

--- a/src/Faithlife.Utility/ReadOnlyStream.cs
+++ b/src/Faithlife.Utility/ReadOnlyStream.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Faithlife.Utility
 {
@@ -33,5 +35,10 @@ namespace Faithlife.Utility
 		/// within this stream by the number of bytes written.
 		/// </summary>
 		public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+		/// <summary>
+		/// Asynchronously reads a sequence of bytes from the current stream, advances the position within the stream by the number of bytes read, and monitors cancellation requests.
+		/// </summary>
+		public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => WrappedStream.ReadAsync(buffer, offset, count, cancellationToken);
 	}
 }

--- a/src/Faithlife.Utility/ReadOnlyStream.cs
+++ b/src/Faithlife.Utility/ReadOnlyStream.cs
@@ -37,8 +37,20 @@ namespace Faithlife.Utility
 		public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
 
 		/// <summary>
+		/// Asynchronously writes a sequence of bytes to the current stream, advances the current position within this stream by the number of bytes written, and monitors cancellation requests.
+		/// </summary>
+		public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => throw new NotSupportedException();
+
+		/// <summary>
+		/// Reads a sequence of bytes from the current stream and advances the position
+		/// within the stream by the number of bytes read.
+		/// </summary>
+		public override int Read(byte[] buffer, int offset, int count) => WrappedStream.Read(buffer, offset, count);
+
+		/// <summary>
 		/// Asynchronously reads a sequence of bytes from the current stream, advances the position within the stream by the number of bytes read, and monitors cancellation requests.
 		/// </summary>
-		public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => WrappedStream.ReadAsync(buffer, offset, count, cancellationToken);
+		public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>
+			WrappedStream.ReadAsync(buffer, offset, count, cancellationToken);
 	}
 }

--- a/src/Faithlife.Utility/ReadOnlyStream.cs
+++ b/src/Faithlife.Utility/ReadOnlyStream.cs
@@ -6,7 +6,7 @@ namespace Faithlife.Utility
 	/// <summary>
 	/// A read-only stream wrapper.
 	/// </summary>
-	public sealed class ReadOnlyStream : WrappingStream
+	public sealed class ReadOnlyStream : WrappingStreamBase
 	{
 		/// <summary>
 		/// Initializes a new instance of the <see cref="ReadOnlyStream"/> class.
@@ -33,22 +33,5 @@ namespace Faithlife.Utility
 		/// within this stream by the number of bytes written.
 		/// </summary>
 		public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
-
-		/// <summary>
-		/// Writes a byte to the current position in the stream and advances the position within the stream by one byte.
-		/// </summary>
-		public override void WriteByte(byte value) => throw new NotSupportedException();
-
-#if !NETSTANDARD1_4
-		/// <summary>
-		/// Begins an asynchronous write operation.
-		/// </summary>
-		public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state) => throw new NotSupportedException();
-
-		/// <summary>
-		/// Ends an asynchronous write operation.
-		/// </summary>
-		public override void EndWrite(IAsyncResult asyncResult) => throw new NotSupportedException();
-#endif
 	}
 }

--- a/src/Faithlife.Utility/RebasedStream.cs
+++ b/src/Faithlife.Utility/RebasedStream.cs
@@ -3,9 +3,9 @@ using System.IO;
 namespace Faithlife.Utility
 {
 	/// <summary>
-	/// <see cref="RebasedStream"/> is a <see cref="WrappingStream"/> that changes the effective origin of the wrapped stream.
+	/// <see cref="RebasedStream"/> is a stream wrapper that changes the effective origin of the wrapped stream.
 	/// </summary>
-	public sealed class RebasedStream : WrappingStream
+	public sealed class RebasedStream : WrappingStreamBase
 	{
 		/// <summary>
 		/// Initializes a new instance of the <see cref="RebasedStream"/> class; the current position in <paramref name="stream"/>

--- a/src/Faithlife.Utility/RebasedStream.cs
+++ b/src/Faithlife.Utility/RebasedStream.cs
@@ -1,4 +1,6 @@
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Faithlife.Utility
 {
@@ -62,6 +64,18 @@ namespace Faithlife.Utility
 		/// </summary>
 		/// <param name="value">The desired length of the current stream in bytes.</param>
 		public override void SetLength(long value) => base.SetLength(value + m_baseOffset);
+
+		/// <summary>
+		/// Asynchronously reads a sequence of bytes from the current stream, advances the position within the stream by the number of bytes read, and monitors cancellation requests.
+		/// </summary>
+		public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>
+			WrappedStream.ReadAsync(buffer, offset, count, cancellationToken);
+
+		/// <summary>
+		/// Asynchronously writes a sequence of bytes to the current stream, advances the current position within this stream by the number of bytes written, and monitors cancellation requests.
+		/// </summary>
+		public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>
+			WrappedStream.WriteAsync(buffer, offset, count, cancellationToken);
 
 		// the offset within the base stream where this stream begins
 		readonly long m_baseOffset;

--- a/src/Faithlife.Utility/RebasedStream.cs
+++ b/src/Faithlife.Utility/RebasedStream.cs
@@ -66,10 +66,22 @@ namespace Faithlife.Utility
 		public override void SetLength(long value) => base.SetLength(value + m_baseOffset);
 
 		/// <summary>
+		/// Reads a sequence of bytes from the current stream and advances the position
+		/// within the stream by the number of bytes read.
+		/// </summary>
+		public override int Read(byte[] buffer, int offset, int count) => WrappedStream.Read(buffer, offset, count);
+
+		/// <summary>
 		/// Asynchronously reads a sequence of bytes from the current stream, advances the position within the stream by the number of bytes read, and monitors cancellation requests.
 		/// </summary>
 		public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>
 			WrappedStream.ReadAsync(buffer, offset, count, cancellationToken);
+
+		/// <summary>
+		/// Writes a sequence of bytes to the current stream and advances the current position
+		/// within this stream by the number of bytes written.
+		/// </summary>
+		public override void Write(byte[] buffer, int offset, int count) => WrappedStream.Write(buffer, offset, count);
 
 		/// <summary>
 		/// Asynchronously writes a sequence of bytes to the current stream, advances the current position within this stream by the number of bytes written, and monitors cancellation requests.

--- a/src/Faithlife.Utility/StreamUtility.cs
+++ b/src/Faithlife.Utility/StreamUtility.cs
@@ -25,6 +25,21 @@ namespace Faithlife.Utility
 		}
 
 		/// <summary>
+		/// Reads all bytes from the stream.
+		/// </summary>
+		/// <param name="stream">The stream.</param>
+		/// <param name="cancellationToken">The cancellation token.</param>
+		/// <returns>An array of all bytes read from the stream.</returns>
+		public static async Task<byte[]> ReadAllBytesAsync(this Stream stream, CancellationToken cancellationToken = default(CancellationToken))
+		{
+			using (MemoryStream streamMemory = new MemoryStream())
+			{
+				await stream.CopyToAsync(streamMemory, 81920, cancellationToken);
+				return streamMemory.ToArray();
+			}
+		}
+
+		/// <summary>
 		/// Reads <paramref name="count"/> bytes from <paramref name="stream"/> into
 		/// <paramref name="buffer"/>, starting at the byte given by <paramref name="offset"/>.
 		/// </summary>
@@ -123,6 +138,22 @@ namespace Faithlife.Utility
 		}
 
 		/// <summary>
+		/// Reads exactly <paramref name="count"/> bytes from <paramref name="stream"/>.
+		/// </summary>
+		/// <param name="stream">The stream to read from.</param>
+		/// <param name="count">The count of bytes to read.</param>
+		/// <param name="cancellationToken">The cancellation token.</param>
+		/// <returns>A new byte array containing the data read from the stream.</returns>
+		public static async Task<byte[]> ReadExactlyAsync(this Stream stream, int count, CancellationToken cancellationToken = default(CancellationToken))
+		{
+			if (count < 0)
+				throw new ArgumentOutOfRangeException(nameof(count));
+			byte[] buffer = new byte[count];
+			await ReadExactlyAsync(stream, buffer, 0, count, cancellationToken).ConfigureAwait(false);
+			return buffer;
+		}
+
+		/// <summary>
 		/// Reads exactly <paramref name="count"/> bytes from <paramref name="stream"/> into
 		/// <paramref name="buffer"/>, starting at the byte given by <paramref name="offset"/>.
 		/// </summary>
@@ -133,6 +164,21 @@ namespace Faithlife.Utility
 		public static void ReadExactly(this Stream stream, byte[] buffer, int offset, int count)
 		{
 			if (stream.ReadBlock(buffer, offset, count) != count)
+				throw new EndOfStreamException();
+		}
+
+		/// <summary>
+		/// Reads exactly <paramref name="count"/> bytes from <paramref name="stream"/> into
+		/// <paramref name="buffer"/>, starting at the byte given by <paramref name="offset"/>.
+		/// </summary>
+		/// <param name="stream">The stream to read from.</param>
+		/// <param name="buffer">The buffer to read data into.</param>
+		/// <param name="offset">The offset within the buffer at which data is first written.</param>
+		/// <param name="count">The count of bytes to read.</param>
+		/// <param name="cancellationToken">The cancellation token.</param>
+		public static async Task ReadExactlyAsync(this Stream stream, byte[] buffer, int offset, int count, CancellationToken cancellationToken = default(CancellationToken))
+		{
+			if (await stream.ReadBlockAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false) != count)
 				throw new EndOfStreamException();
 		}
 

--- a/src/Faithlife.Utility/TruncatedStream.cs
+++ b/src/Faithlife.Utility/TruncatedStream.cs
@@ -97,6 +97,11 @@ namespace Faithlife.Utility
 		public override void Write(byte[] buffer, int offset, int count) => throw CreateWriteNotSupportedException();
 
 		/// <summary>
+		/// Asynchronously writes a sequence of bytes to the current stream, advances the current position within this stream by the number of bytes written, and monitors cancellation requests.
+		/// </summary>
+		public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => throw CreateWriteNotSupportedException();
+
+		/// <summary>
 		/// Throws an exception; writes are not supported.
 		/// </summary>
 		public override void Flush() => throw CreateWriteNotSupportedException();

--- a/src/Faithlife.Utility/TruncatedStream.cs
+++ b/src/Faithlife.Utility/TruncatedStream.cs
@@ -6,9 +6,9 @@ using System.Threading.Tasks;
 namespace Faithlife.Utility
 {
 	/// <summary>
-	/// <see cref="TruncatedStream"/> is a read-only <see cref="WrappingStream"/> that will not read past the specified length.
+	/// <see cref="TruncatedStream"/> is a read-only stream wrapper that will not read past the specified length.
 	/// </summary>
-	public sealed class TruncatedStream : WrappingStream
+	public sealed class TruncatedStream : WrappingStreamBase
 	{
 		/// <summary>
 		/// Creates a new truncated stream.
@@ -30,76 +30,25 @@ namespace Faithlife.Utility
 		/// <summary>
 		/// Returns the (truncated) length of the stream.
 		/// </summary>
-		public override long Length => Math.Min(m_length, base.Length);
+		public override long Length => Math.Min(m_length, WrappedStream.Length);
 
 		/// <summary>
 		/// The current position in the stream.
 		/// </summary>
 		public override long Position
 		{
-			get => base.Position;
-			set => m_offset = base.Position = value;
+			get => WrappedStream.Position;
+			set => m_offset = WrappedStream.Position = value;
 		}
-
-#if !NETSTANDARD1_4
-		/// <summary>
-		/// Starts an asynchronous read.
-		/// </summary>
-		public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state) => base.BeginRead(buffer, offset, TruncateCount(count), callback, state);
-
-		/// <summary>
-		/// Throws an exception; writes are not supported.
-		/// </summary>
-		public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state) => throw CreateWriteNotSupportedException();
-
-		/// <summary>
-		/// Finishes an asynchronous read.
-		/// </summary>
-		public override int EndRead(IAsyncResult asyncResult)
-		{
-			int byteCount = base.EndRead(asyncResult);
-			m_offset += byteCount;
-			return byteCount;
-		}
-
-		/// <summary>
-		/// Throws an exception; writes are not supported.
-		/// </summary>
-		public override void EndWrite(IAsyncResult asyncResult) => throw CreateWriteNotSupportedException();
-#endif
 
 		/// <summary>
 		/// Reads from the stream.
 		/// </summary>
 		public override int Read(byte[] buffer, int offset, int count)
 		{
-			int byteCount = base.Read(buffer, offset, TruncateCount(count));
+			int byteCount = WrappedStream.Read(buffer, offset, TruncateCount(count));
 			m_offset += byteCount;
 			return byteCount;
-		}
-
-		/// <summary>
-		/// Reads from the stream asynchronously.
-		/// </summary>
-		public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
-		{
-			int byteCount = await base.ReadAsync(buffer, offset, TruncateCount(count), cancellationToken).ConfigureAwait(false);
-			m_offset += byteCount;
-			return byteCount;
-		}
-
-		/// <summary>
-		/// Reads a byte from the stream.
-		/// </summary>
-		public override int ReadByte()
-		{
-			if (m_offset >= m_length)
-				return -1;
-
-			int ch = base.ReadByte();
-			if (ch != -1)
-				m_offset++;
-			return ch;
 		}
 
 		/// <summary>
@@ -108,9 +57,9 @@ namespace Faithlife.Utility
 		public override long Seek(long offset, SeekOrigin origin)
 		{
 			if (origin == SeekOrigin.End)
-				offset -= base.Length - m_length;
+				offset -= WrappedStream.Length - m_length;
 
-			return m_offset = base.Seek(offset, origin);
+			return m_offset = WrappedStream.Seek(offset, origin);
 		}
 
 		/// <summary>
@@ -126,12 +75,7 @@ namespace Faithlife.Utility
 		/// <summary>
 		/// Throws an exception; writes are not supported.
 		/// </summary>
-		public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => throw CreateWriteNotSupportedException();
-
-		/// <summary>
-		/// Throws an exception; writes are not supported.
-		/// </summary>
-		public override void WriteByte(byte value) => throw CreateWriteNotSupportedException();
+		public override void Flush() => throw CreateWriteNotSupportedException();
 
 		private int TruncateCount(int count)
 		{

--- a/src/Faithlife.Utility/TruncatedStream.cs
+++ b/src/Faithlife.Utility/TruncatedStream.cs
@@ -52,6 +52,30 @@ namespace Faithlife.Utility
 		}
 
 		/// <summary>
+		/// Reads from the stream asynchronously.
+		/// </summary>
+		public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+		{
+			int byteCount = await WrappedStream.ReadAsync(buffer, offset, TruncateCount(count), cancellationToken).ConfigureAwait(false);
+			m_offset += byteCount;
+			return byteCount;
+		}
+
+		/// <summary>
+		/// Reads a byte from the stream.
+		/// </summary>
+		public override int ReadByte()
+		{
+			if (m_offset >= m_length)
+				return -1;
+
+			int ch = base.ReadByte();
+			if (ch != -1)
+				m_offset++;
+			return ch;
+		}
+
+		/// <summary>
 		/// Changes the current position in the stream.
 		/// </summary>
 		public override long Seek(long offset, SeekOrigin origin)

--- a/src/Faithlife.Utility/WrappingStream.cs
+++ b/src/Faithlife.Utility/WrappingStream.cs
@@ -123,12 +123,6 @@ namespace Faithlife.Utility
 			WrappedStream.ReadAsync(buffer, offset, count, cancellationToken);
 
 		/// <summary>
-		/// Asynchronously reads the bytes from the current stream and writes them to another stream, using a specified buffer size and cancellation token.
-		/// </summary>
-		public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken) =>
-			WrappedStream.CopyToAsync(destination, bufferSize, cancellationToken);
-
-		/// <summary>
 		/// Sets the position within the current stream.
 		/// </summary>
 		/// <param name="offset">A byte offset relative to the <paramref name="origin"/> parameter.</param>

--- a/src/Faithlife.Utility/WrappingStreamBase.cs
+++ b/src/Faithlife.Utility/WrappingStreamBase.cs
@@ -114,6 +114,10 @@ namespace Faithlife.Utility
 			set => WrappedStream.WriteTimeout = value;
 		}
 
+#if !NETSTANDARD1_4
+		public sealed override void Close() => base.Close();
+#endif
+
 		/// <summary>
 		/// Gets the wrapped stream.
 		/// </summary>

--- a/src/Faithlife.Utility/WrappingStreamBase.cs
+++ b/src/Faithlife.Utility/WrappingStreamBase.cs
@@ -69,10 +69,9 @@ namespace Faithlife.Utility
 		public override void Flush() => WrappedStream.Flush();
 
 		/// <summary>
-		/// Reads a sequence of bytes from the current stream and advances the position
-		/// within the stream by the number of bytes read.
+		/// Asynchronously reads a sequence of bytes from the current stream, advances the position within the stream by the number of bytes read, and monitors cancellation requests.
 		/// </summary>
-		public override int Read(byte[] buffer, int offset, int count) => WrappedStream.Read(buffer, offset, count);
+		public override abstract Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken);
 
 		/// <summary>
 		/// Gets or sets a value, in milliseconds, that determines how long the stream will attempt to read before timing out.
@@ -102,7 +101,7 @@ namespace Faithlife.Utility
 		/// Writes a sequence of bytes to the current stream and advances the current position
 		/// within this stream by the number of bytes written.
 		/// </summary>
-		public override void Write(byte[] buffer, int offset, int count) => WrappedStream.Write(buffer, offset, count);
+		public override abstract Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken);
 
 		/// <summary>
 		/// Gets or sets a value, in milliseconds, that determines how long the stream will attempt to write before timing out.

--- a/src/Faithlife.Utility/WrappingStreamBase.cs
+++ b/src/Faithlife.Utility/WrappingStreamBase.cs
@@ -6,18 +6,20 @@ using System.Threading.Tasks;
 namespace Faithlife.Utility
 {
 	/// <summary>
-	/// A <see cref="Stream"/> that wraps another stream. One major feature of <see cref="WrappingStream"/> is that it does not dispose the
-	/// underlying stream when it is disposed if Ownership.None is used; this is useful when using classes such as <see cref="BinaryReader"/>
-	/// that take ownership of the stream passed to their constructors.
+	/// A <see cref="Stream"/> that wraps another stream. One major feature of this class is that it does not dispose the underlying stream
+	/// when it is disposed if <see cref="Ownership.None"/> is used; this is useful when using classes such as <see cref="BinaryReader"/>
+	/// that take ownership of the stream passed to their constructors. This class delegates a minimal number of properties and methods to
+	/// the wrapped stream so that inheritors can override this class as they would <see cref="Stream"/>, e.g. override Read and get
+	/// correct behavior for ReadAsync and CopyToAsync.
 	/// </summary>
-	public sealed class WrappingStream : Stream
+	public abstract class WrappingStreamBase : Stream
 	{
 		/// <summary>
-		/// Initializes a new instance of the <see cref="WrappingStream"/> class.
+		/// Initializes a new instance of the <see cref="WrappingStreamBase"/> class.
 		/// </summary>
 		/// <param name="stream">The wrapped stream.</param>
 		/// <param name="ownership">Use Owns if the wrapped stream should be disposed when this stream is disposed.</param>
-		public WrappingStream(Stream stream, Ownership ownership)
+		protected WrappingStreamBase(Stream stream, Ownership ownership)
 		{
 			m_wrappedStream = stream ?? throw new ArgumentNullException(nameof(stream));
 			m_ownership = ownership;
@@ -61,50 +63,16 @@ namespace Faithlife.Utility
 			set => WrappedStream.Position = value;
 		}
 
-#if !NETSTANDARD1_4
-		/// <summary>
-		/// Begins an asynchronous read operation.
-		/// </summary>
-		public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state) =>
-			WrappedStream.BeginRead(buffer, offset, count, callback, state);
-
-		/// <summary>
-		/// Begins an asynchronous write operation.
-		/// </summary>
-		public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state) =>
-			WrappedStream.BeginWrite(buffer, offset, count, callback, state);
-
-		/// <summary>
-		/// Waits for the pending asynchronous read to complete.
-		/// </summary>
-		public override int EndRead(IAsyncResult asyncResult) => WrappedStream.EndRead(asyncResult);
-
-		/// <summary>
-		/// Ends an asynchronous write operation.
-		/// </summary>
-		public override void EndWrite(IAsyncResult asyncResult) => WrappedStream.EndWrite(asyncResult);
-#endif
-
 		/// <summary>
 		/// Clears all buffers for this stream and causes any buffered data to be written to the underlying device.
 		/// </summary>
 		public override void Flush() => WrappedStream.Flush();
 
 		/// <summary>
-		/// Asynchronously clears all buffers for this stream, causes any buffered data to be written to the underlying device, and monitors cancellation requests.
-		/// </summary>
-		public override Task FlushAsync(CancellationToken cancellationToken) => WrappedStream.FlushAsync(cancellationToken);
-
-		/// <summary>
 		/// Reads a sequence of bytes from the current stream and advances the position
 		/// within the stream by the number of bytes read.
 		/// </summary>
 		public override int Read(byte[] buffer, int offset, int count) => WrappedStream.Read(buffer, offset, count);
-
-		/// <summary>
-		/// Reads a byte from the stream and advances the position within the stream by one byte, or returns -1 if at the end of the stream.
-		/// </summary>
-		public override int ReadByte() => WrappedStream.ReadByte();
 
 		/// <summary>
 		/// Gets or sets a value, in milliseconds, that determines how long the stream will attempt to read before timing out.
@@ -115,18 +83,6 @@ namespace Faithlife.Utility
 			get => WrappedStream.ReadTimeout;
 			set => WrappedStream.ReadTimeout = value;
 		}
-
-		/// <summary>
-		/// Asynchronously reads a sequence of bytes from the current stream, advances the position within the stream by the number of bytes read, and monitors cancellation requests.
-		/// </summary>
-		public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>
-			WrappedStream.ReadAsync(buffer, offset, count, cancellationToken);
-
-		/// <summary>
-		/// Asynchronously reads the bytes from the current stream and writes them to another stream, using a specified buffer size and cancellation token.
-		/// </summary>
-		public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken) =>
-			WrappedStream.CopyToAsync(destination, bufferSize, cancellationToken);
 
 		/// <summary>
 		/// Sets the position within the current stream.
@@ -149,11 +105,6 @@ namespace Faithlife.Utility
 		public override void Write(byte[] buffer, int offset, int count) => WrappedStream.Write(buffer, offset, count);
 
 		/// <summary>
-		/// Writes a byte to the current position in the stream and advances the position within the stream by one byte.
-		/// </summary>
-		public override void WriteByte(byte value) => WrappedStream.WriteByte(value);
-
-		/// <summary>
 		/// Gets or sets a value, in milliseconds, that determines how long the stream will attempt to write before timing out.
 		/// </summary>
 		/// <value>A value, in milliseconds, that determines how long the stream will attempt to write before timing out.</value>
@@ -164,10 +115,17 @@ namespace Faithlife.Utility
 		}
 
 		/// <summary>
-		/// Asynchronously writes a sequence of bytes to the current stream, advances the current position within this stream by the number of bytes written, and monitors cancellation requests.
+		/// Gets the wrapped stream.
 		/// </summary>
-		public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>
-			WrappedStream.WriteAsync(buffer, offset, count, cancellationToken);
+		/// <value>The wrapped stream.</value>
+		protected Stream WrappedStream
+		{
+			get
+			{
+				ThrowIfDisposed();
+				return m_wrappedStream;
+			}
+		}
 
 		/// <summary>
 		/// Disposes or releases the wrapped stream, based on the value of the Ownership parameter passed to the constructor.
@@ -193,18 +151,13 @@ namespace Faithlife.Utility
 		}
 
 		/// <summary>
-		/// Gets the wrapped stream.
+		/// Throws an <see cref="ObjectDisposedException"/> if this object has been disposed.
 		/// </summary>
-		/// <value>The wrapped stream.</value>
-		private Stream WrappedStream
+		protected void ThrowIfDisposed()
 		{
-			get
-			{
-				// throws an ObjectDisposedException if this object has been disposed
-				if (m_wrappedStream == null)
-					throw new ObjectDisposedException(nameof(WrappingStream));
-				return m_wrappedStream;
-			}
+			// throws an ObjectDisposedException if this object has been disposed
+			if (m_wrappedStream == null)
+				throw new ObjectDisposedException(GetType().Name);
 		}
 
 		Stream m_wrappedStream;

--- a/tests/Faithlife.Utility.Tests/CachingStreamTests.cs
+++ b/tests/Faithlife.Utility.Tests/CachingStreamTests.cs
@@ -134,7 +134,7 @@ namespace Faithlife.Utility.Tests
 					int length = random.Next(1, data.Length - offset);
 
 					Assert.AreEqual(offset, cachingStream.Seek(offset, SeekOrigin.Begin));
-					var read = await ReadExactlyAsync(cachingStream, length);
+					var read = await cachingStream.ReadExactlyAsync(length);
 					Assert.AreEqual(data.Skip(offset).Take(length), read);
 				}
 			}
@@ -246,31 +246,6 @@ namespace Faithlife.Utility.Tests
 				results[index] = temp[index % 4];
 			}
 			return results;
-		}
-
-		private static async Task<byte[]> ReadExactlyAsync(Stream stream, int count)
-		{
-			byte[] buffer = new byte[count];
-			int offset = 0;
-
-			// track total bytes read
-			int totalBytesRead = 0;
-			while (count > 0)
-			{
-				// read data
-				int bytesRead = await stream.ReadAsync(buffer, offset, count).ConfigureAwait(false);
-
-				// check for end of stream
-				if (bytesRead == 0)
-					break;
-
-				// move to next block
-				offset += bytesRead;
-				count -= bytesRead;
-				totalBytesRead += bytesRead;
-			}
-
-			return buffer;
 		}
 	}
 }

--- a/tests/Faithlife.Utility.Tests/CachingStreamTests.cs
+++ b/tests/Faithlife.Utility.Tests/CachingStreamTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using NUnit.Framework;
 
 namespace Faithlife.Utility.Tests
@@ -23,7 +24,7 @@ namespace Faithlife.Utility.Tests
 				Assert.Throws<ObjectDisposedException>(() => cachingStream.ReadByte());
 				Assert.Throws<ObjectDisposedException>(() => cachingStream.Read(new byte[10], 0, 1));
 				Assert.Throws<ObjectDisposedException>(() => cachingStream.Seek(1, SeekOrigin.Begin));
-			}			
+			}
 		}
 
 		[TestCase(0)]
@@ -119,6 +120,72 @@ namespace Faithlife.Utility.Tests
 			}
 		}
 
+		[Test]
+		public async Task SeekAndReadAsync()
+		{
+			Random random = new Random(1);
+			var data = GenerateData(1234567);
+			using (var memoryStream = new MemoryStream(data, writable: false))
+			using (var cachingStream = new CachingStream(memoryStream, Ownership.Owns))
+			{
+				for (int i = 0; i < 100; i++)
+				{
+					int offset = random.Next(data.Length - 100);
+					int length = random.Next(1, data.Length - offset);
+
+					Assert.AreEqual(offset, cachingStream.Seek(offset, SeekOrigin.Begin));
+					var read = await ReadExactlyAsync(cachingStream, length);
+					Assert.AreEqual(data.Skip(offset).Take(length), read);
+				}
+			}
+		}
+
+		[Test]
+		public void SeekAndCopyTo()
+		{
+			Random random = new Random(1);
+			var data = GenerateData(54321);
+			using (var memoryStream = new MemoryStream(data, writable: false))
+			using (var cachingStream = new CachingStream(memoryStream, Ownership.Owns))
+			{
+				for (int i = 0; i < 100; i++)
+				{
+					int offset = random.Next(data.Length - 100);
+
+					Assert.AreEqual(offset, cachingStream.Seek(offset, SeekOrigin.Begin));
+
+					using (var destination = new MemoryStream(data.Length))
+					{
+						cachingStream.CopyTo(destination);
+						Assert.AreEqual(data.Skip(offset), destination.ToArray());
+					}
+				}
+			}
+		}
+
+		[Test]
+		public async Task SeekAndCopyToAsync()
+		{
+			Random random = new Random(1);
+			var data = GenerateData(54321);
+			using (var memoryStream = new MemoryStream(data, writable: false))
+			using (var cachingStream = new CachingStream(memoryStream, Ownership.Owns))
+			{
+				for (int i = 0; i < 100; i++)
+				{
+					int offset = random.Next(data.Length - 100);
+
+					Assert.AreEqual(offset, cachingStream.Seek(offset, SeekOrigin.Begin));
+
+					using (var destination = new MemoryStream(data.Length))
+					{
+						await cachingStream.CopyToAsync(destination);
+						Assert.AreEqual(data.Skip(offset), destination.ToArray());
+					}
+				}
+			}
+		}
+
 		[TestCase(1000)]
 		[TestCase(1001)]
 		[TestCase(4000)]
@@ -165,6 +232,7 @@ namespace Faithlife.Utility.Tests
 				Assert.Throws<NotSupportedException>(() => cachingStream.Write(new byte[1], 0, 1));
 				Assert.Throws<NotSupportedException>(() => cachingStream.WriteByte(1));
 				Assert.Throws<NotSupportedException>(() => cachingStream.BeginWrite(new byte[1], 0, 1, null, null));
+				Assert.Throws<NotSupportedException>(() => cachingStream.WriteAsync(new byte[1], 0, 1));
 			}
 		}
 
@@ -178,6 +246,31 @@ namespace Faithlife.Utility.Tests
 				results[index] = temp[index % 4];
 			}
 			return results;
+		}
+
+		private static async Task<byte[]> ReadExactlyAsync(Stream stream, int count)
+		{
+			byte[] buffer = new byte[count];
+			int offset = 0;
+
+			// track total bytes read
+			int totalBytesRead = 0;
+			while (count > 0)
+			{
+				// read data
+				int bytesRead = await stream.ReadAsync(buffer, offset, count).ConfigureAwait(false);
+
+				// check for end of stream
+				if (bytesRead == 0)
+					break;
+
+				// move to next block
+				offset += bytesRead;
+				count -= bytesRead;
+				totalBytesRead += bytesRead;
+			}
+
+			return buffer;
 		}
 	}
 }

--- a/tests/Faithlife.Utility.Tests/ReadOnlyStreamTests.cs
+++ b/tests/Faithlife.Utility.Tests/ReadOnlyStreamTests.cs
@@ -1,6 +1,6 @@
 using System;
 using System.IO;
-
+using System.Threading.Tasks;
 using NUnit.Framework;
 
 namespace Faithlife.Utility.Tests
@@ -87,12 +87,38 @@ namespace Faithlife.Utility.Tests
 		}
 
 		[Test]
+		public async Task ReadAsync()
+		{
+			byte[] aby = new byte[m_abyStreamData.Length];
+			Assert.AreEqual(aby.Length, await m_stream.ReadAsync(aby, 0, aby.Length));
+			CollectionAssert.AreEqual(m_abyStreamData, aby);
+		}
+
+		[Test]
+		public void CopyTo()
+		{
+			byte[] aby = new byte[m_abyStreamData.Length];
+			var destination = new MemoryStream(aby);
+			m_stream.CopyTo(destination);
+			CollectionAssert.AreEqual(m_abyStreamData, aby);
+		}
+
+		[Test]
+		public async Task CopyToAsync()
+		{
+			byte[] aby = new byte[m_abyStreamData.Length];
+			var destination = new MemoryStream(aby);
+			await m_stream.CopyToAsync(destination);
+			CollectionAssert.AreEqual(m_abyStreamData, aby);
+		}
+
+		[Test]
 		public void Write()
 		{
 			Assert.Throws<NotSupportedException>(delegate { m_stream.Write(m_abyStreamData, 0, 1); });
 			Assert.Throws<NotSupportedException>(delegate { m_stream.WriteByte(0); });
 			Assert.Throws<NotSupportedException>(delegate { m_stream.BeginWrite(m_abyStreamData, 0, 1, null, null); });
-			Assert.Throws<NotSupportedException>(delegate { m_stream.EndWrite(null); });
+			Assert.Throws<NotSupportedException>(delegate { m_stream.WriteAsync(m_abyStreamData, 0, 1); });
 			Assert.Throws<NotSupportedException>(delegate { m_stream.SetLength(0); });
 		}
 

--- a/tests/Faithlife.Utility.Tests/RebasedStreamTests.cs
+++ b/tests/Faithlife.Utility.Tests/RebasedStreamTests.cs
@@ -1,6 +1,6 @@
 using System;
 using System.IO;
-
+using System.Threading.Tasks;
 using NUnit.Framework;
 
 namespace Faithlife.Utility.Tests
@@ -105,6 +105,41 @@ namespace Faithlife.Utility.Tests
 			{
 				byte[] buffer = new byte[16];
 				Assert.AreEqual(9, stream.Read(buffer, 0, buffer.Length));
+				CollectionAssert.AreEqual(new byte[] { 4, 5, 6, 7, 8, 9, 10, 11, 12, 0, 0, 0, 0, 0, 0, 0 }, buffer);
+			}
+		}
+
+		[Test]
+		public async Task ReadAsync()
+		{
+			using (RebasedStream stream = CreateRebasedStream(3))
+			{
+				byte[] buffer = new byte[16];
+				Assert.AreEqual(9, await stream.ReadAsync(buffer, 0, buffer.Length));
+				CollectionAssert.AreEqual(new byte[] { 4, 5, 6, 7, 8, 9, 10, 11, 12, 0, 0, 0, 0, 0, 0, 0 }, buffer);
+			}
+		}
+
+		[Test]
+		public void CopyTo()
+		{
+			using (RebasedStream stream = CreateRebasedStream(3))
+			{
+				byte[] buffer = new byte[16];
+				var destination = new MemoryStream(buffer);
+				stream.CopyTo(destination);
+				CollectionAssert.AreEqual(new byte[] { 4, 5, 6, 7, 8, 9, 10, 11, 12, 0, 0, 0, 0, 0, 0, 0 }, buffer);
+			}
+		}
+
+		[Test]
+		public async Task CopyToAsync()
+		{
+			using (RebasedStream stream = CreateRebasedStream(3))
+			{
+				byte[] buffer = new byte[16];
+				var destination = new MemoryStream(buffer);
+				await stream.CopyToAsync(destination);
 				CollectionAssert.AreEqual(new byte[] { 4, 5, 6, 7, 8, 9, 10, 11, 12, 0, 0, 0, 0, 0, 0, 0 }, buffer);
 			}
 		}

--- a/tests/Faithlife.Utility.Tests/StreamUtilityTests.cs
+++ b/tests/Faithlife.Utility.Tests/StreamUtilityTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using NUnit.Framework;
 
 namespace Faithlife.Utility.Tests
@@ -107,6 +108,54 @@ namespace Faithlife.Utility.Tests
 
 				Stream partialStream2 = StreamUtility.CreatePartialStream(memoryStream, 6, null, Ownership.None);
 				CollectionAssert.AreEqual(new byte[] { 6, 7, 8, 9, 10 }, partialStream2.ReadAllBytes());
+			}
+		}
+
+		[Test]
+		public void PartialStreamCopyTo()
+		{
+			byte[] bytes = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+			using (MemoryStream memoryStream = new MemoryStream())
+			{
+				memoryStream.Write(bytes, 0, bytes.Length);
+
+				Stream partialStream1 = StreamUtility.CreatePartialStream(memoryStream, 3, 4, Ownership.None);
+				using (var destination = new MemoryStream())
+				{
+					partialStream1.CopyTo(destination);
+					CollectionAssert.AreEqual(new byte[] { 3, 4, 5, 6 }, destination.ToArray());
+				}
+
+				Stream partialStream2 = StreamUtility.CreatePartialStream(memoryStream, 6, null, Ownership.None);
+				using (var destination = new MemoryStream())
+				{
+					partialStream2.CopyTo(destination);
+					CollectionAssert.AreEqual(new byte[] { 6, 7, 8, 9, 10 }, destination.ToArray());
+				}
+			}
+		}
+
+		[Test]
+		public async Task PartialStreamCopyToAsync()
+		{
+			byte[] bytes = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+			using (MemoryStream memoryStream = new MemoryStream())
+			{
+				memoryStream.Write(bytes, 0, bytes.Length);
+
+				Stream partialStream1 = StreamUtility.CreatePartialStream(memoryStream, 3, 4, Ownership.None);
+				using (var destination = new MemoryStream())
+				{
+					await partialStream1.CopyToAsync(destination);
+					CollectionAssert.AreEqual(new byte[] { 3, 4, 5, 6 }, destination.ToArray());
+				}
+
+				Stream partialStream2 = StreamUtility.CreatePartialStream(memoryStream, 6, null, Ownership.None);
+				using (var destination = new MemoryStream())
+				{
+					await partialStream2.CopyToAsync(destination);
+					CollectionAssert.AreEqual(new byte[] { 6, 7, 8, 9, 10 }, destination.ToArray());
+				}
 			}
 		}
 

--- a/tests/Faithlife.Utility.Tests/StreamUtilityTests.cs
+++ b/tests/Faithlife.Utility.Tests/StreamUtilityTests.cs
@@ -110,7 +110,7 @@ namespace Faithlife.Utility.Tests
 			}
 		}
 
-		private class SlowStream : WrappingStream
+		private class SlowStream : WrappingStreamBase
 		{
 			public SlowStream(Stream stream)
 				: base(stream, Ownership.None)

--- a/tests/Faithlife.Utility.Tests/StreamUtilityTests.cs
+++ b/tests/Faithlife.Utility.Tests/StreamUtilityTests.cs
@@ -67,6 +67,37 @@ namespace Faithlife.Utility.Tests
 		}
 
 		[Test]
+		public async Task ReadExactlyAsync()
+		{
+			byte[] abySource = new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+
+			using (Stream streamSource = new MemoryStream(abySource))
+			using (Stream stream = new SlowStream(streamSource))
+			{
+				byte[] read = await stream.ReadExactlyAsync(5);
+				CollectionAssert.AreEqual(abySource.Take(5), read);
+
+				read = await stream.ReadExactlyAsync(6);
+				CollectionAssert.AreEqual(abySource.Skip(5), read);
+
+				Assert.ThrowsAsync<EndOfStreamException>(() => stream.ReadExactlyAsync(1));
+			}
+
+			using (Stream streamSource = new MemoryStream(abySource))
+			using (Stream stream = new SlowStream(streamSource))
+			{
+				byte[] read = await stream.ReadExactlyAsync(11);
+				CollectionAssert.AreEqual(abySource, read);
+			}
+
+			using (Stream streamSource = new MemoryStream(abySource))
+			using (Stream stream = new SlowStream(streamSource))
+			{
+				Assert.ThrowsAsync<EndOfStreamException>(() => stream.ReadExactlyAsync(12));
+			}
+		}
+
+		[Test]
 		public void ReadExactlyArray()
 		{
 			byte[] abySource = new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };

--- a/tests/Faithlife.Utility.Tests/StreamUtilityTests.cs
+++ b/tests/Faithlife.Utility.Tests/StreamUtilityTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
 
@@ -197,10 +198,13 @@ namespace Faithlife.Utility.Tests
 			{
 			}
 
-			public override int Read(byte[] buffer, int offset, int count)
-			{
-				return base.Read(buffer, offset, Math.Min(count, 2));
-			}
+			public override int Read(byte[] buffer, int offset, int count) => WrappedStream.Read(buffer, offset, Math.Min(count, 2));
+
+			public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => WrappedStream.ReadAsync(buffer, offset, Math.Min(count, 2), cancellationToken);
+
+			public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+			public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => throw new NotSupportedException();
 		}
 	}
 }

--- a/tests/Faithlife.Utility.Tests/TruncatedStreamTests.cs
+++ b/tests/Faithlife.Utility.Tests/TruncatedStreamTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Threading.Tasks;
 using NUnit.Framework;
 
 namespace Faithlife.Utility.Tests
@@ -63,6 +64,41 @@ namespace Faithlife.Utility.Tests
 			{
 				byte[] buffer = new byte[16];
 				Assert.AreEqual(5, stream.Read(buffer, 0, buffer.Length));
+				CollectionAssert.AreEqual(new byte[] { 1, 2, 3, 4, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, buffer);
+			}
+		}
+
+		[Test]
+		public async Task ReadAsync()
+		{
+			using (TruncatedStream stream = CreateTruncatedStream(5))
+			{
+				byte[] buffer = new byte[16];
+				Assert.AreEqual(5, await stream.ReadAsync(buffer, 0, buffer.Length));
+				CollectionAssert.AreEqual(new byte[] { 1, 2, 3, 4, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, buffer);
+			}
+		}
+
+		[Test]
+		public void CopyTo()
+		{
+			using (TruncatedStream stream = CreateTruncatedStream(5))
+			{
+				byte[] buffer = new byte[16];
+				var destination = new MemoryStream(buffer);
+				stream.CopyTo(destination);
+				CollectionAssert.AreEqual(new byte[] { 1, 2, 3, 4, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, buffer);
+			}
+		}
+
+		[Test]
+		public async Task CopyToAsync()
+		{
+			using (TruncatedStream stream = CreateTruncatedStream(5))
+			{
+				byte[] buffer = new byte[16];
+				var destination = new MemoryStream(buffer);
+				await stream.CopyToAsync(destination);
 				CollectionAssert.AreEqual(new byte[] { 1, 2, 3, 4, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, buffer);
 			}
 		}


### PR DESCRIPTION
The default implementation calls ReadAsync, which will delegate. A class that inherits from WrappingStream and overrides ReadAsync but not CopyToAsync, e.g. TruncatedStream, will not behave as expected.