### PR TITLE
StringBuilderUtility typo

### DIFF
--- a/VersionHistory.md
+++ b/VersionHistory.md
@@ -7,6 +7,8 @@ is updated in preparation for publishing an updated NuGet package.
 
 Prefix the description of the change with `[major]`, `[minor]` or `[patch]` in accordance with [SemVer](http://semver.org).
 
+* Fix typo in StringBuilderUtility summary for AppendFormatInvariant.
+
 ## Released
 
 ### 0.5.0

--- a/src/Faithlife.Utility/StringBuilderUtility.cs
+++ b/src/Faithlife.Utility/StringBuilderUtility.cs
@@ -9,7 +9,7 @@ namespace Faithlife.Utility
 	public static class StringBuilderUtility
 	{
 		/// <summary>
-		/// Append the invariant representation of the specfied format tot he end of <paramref name="stringBuilder"/>.
+		/// Append the invariant representation of the specfied format to the end of <paramref name="stringBuilder"/>.
 		/// </summary>
 		/// <param name="stringBuilder">The <see cref="StringBuilder"/> instance to which the string representation will be appended.</param>
 		/// <param name="format">A composite format string.</param>


### PR DESCRIPTION
Small spacing error in the summary in StringBuilderUtility for AppendFormatInvariant.