### PR TITLE
Obsolete `TakeLast`

### DIFF
--- a/src/Faithlife.Utility/EnumerableUtility.cs
+++ b/src/Faithlife.Utility/EnumerableUtility.cs
@@ -563,7 +563,14 @@ namespace Faithlife.Utility
 		/// <param name="count">The number of items to take from the end of the sequence.</param>
 		/// <returns>A collection with at most <paramref name="count"/> items, taken from the end of the sequence.</returns>
 		/// <remarks>The source sequence is only evaluated once.</remarks>
-		public static IReadOnlyList<T> TakeLast<T>(this IEnumerable<T> source, int count)
+#if !NETSTANDARD2_0
+		[Obsolete("Use System.Linq.Enumerable.TakeLast instead (available in netcoreapp2.0, netstandard2.1)")]
+#endif
+		public static IReadOnlyList<T> TakeLast<T>(
+#if NETSTANDARD2_0
+			this
+#endif
+			IEnumerable<T> source, int count)
 		{
 			if (source is null)
 				throw new ArgumentNullException(nameof(source));


### PR DESCRIPTION
Resolves #40. Just got bit by this one trying to duke it out with System.Linq.

I've confirmed in the docs that `Enumerable.TakeLast` is available in [Core 2.0](https://docs.microsoft.com/en-us/dotnet/api/system.linq.enumerable.takelast?view=netcore-2.0), [Standard 2.1](https://docs.microsoft.com/en-us/dotnet/api/system.linq.enumerable.takelast?view=netstandard-2.1), [5.0](https://docs.microsoft.com/en-us/dotnet/api/system.linq.enumerable.takelast?view=net-5.0), and [6.0 Preview 7](https://docs.microsoft.com/en-us/dotnet/api/system.linq.enumerable.takelast?view=net-6.0). And that it's _not_ available in [Standard 2.0](https://docs.microsoft.com/en-us/dotnet/api/system.linq.enumerable.takelast?view=netstandard-2.0).