### PR TITLE
Add `string.ContainsOrdinal`

### DIFF
--- a/src/Faithlife.Utility/StringUtility.cs
+++ b/src/Faithlife.Utility/StringUtility.cs
@@ -79,7 +79,8 @@ namespace Faithlife.Utility
 		}
 
 		/// <summary>
-		/// Calls string.<see cref="string.Contains(char, StringComparison)"/> with StringComparison.<see cref="StringComparison.Ordinal"/>.
+		/// Calls <see cref="string.Contains(char, StringComparison)">string.Contains</see> with
+		/// <see cref="StringComparison.Ordinal">StringComparison.Ordinal</see>.
 		/// </summary>
 		public static bool ContainsOrdinal(this string source, char value) =>
 #if NETSTANDARD2_0
@@ -89,7 +90,8 @@ namespace Faithlife.Utility
 #endif
 
 		/// <summary>
-		/// Calls string.<see cref="string.Contains(string, StringComparison)"/> with StringComparison.<see cref="StringComparison.Ordinal"/>.
+		/// Calls <see cref="string.Contains(string, StringComparison)">string.Contains</see> with
+		/// <see cref="StringComparison.Ordinal">StringComparison.Ordinal</see>.
 		/// </summary>
 		public static bool ContainsOrdinal(this string source, string value) =>
 #if NETSTANDARD2_0

--- a/src/Faithlife.Utility/StringUtility.cs
+++ b/src/Faithlife.Utility/StringUtility.cs
@@ -904,17 +904,6 @@ namespace Faithlife.Utility
 			source.Contains(value, StringComparison.Ordinal);
 #endif
 
-		public static bool ContainsAllOrdinal(this string source, IEnumerable<string> values) =>
-			values.All(source.ContainsOrdinal);
-
-		public static bool ContainsAllOrdinal(this string source, params string[] values) =>
-			source.ContainsAllOrdinal(values.AsEnumerable());
-
-#if !NETSTANDARD2_0
-		public static bool ContainsAll(this string source, IEnumerable<string> values, StringComparison comparisonType) =>
-			values.All(value => source.Contains(value, comparisonType));
-#endif
-
 		private sealed class CompressingTextWriter : TextWriter
 		{
 			public CompressingTextWriter(Stream stream, Ownership ownership)

--- a/src/Faithlife.Utility/StringUtility.cs
+++ b/src/Faithlife.Utility/StringUtility.cs
@@ -78,10 +78,15 @@ namespace Faithlife.Utility
 #endif
 		}
 
+#if NETSTANDARD2_0
 		/// <summary>
-		/// Calls <see cref="string.Contains(char, StringComparison)">string.Contains</see> with
-		/// <see cref="StringComparison.Ordinal">StringComparison.Ordinal</see>.
+		/// Calls string.Contains with StringComparison.Ordinal.
 		/// </summary>
+#else
+		/// <summary>
+		/// Calls <see cref="string.Contains(char, StringComparison)">string.Contains</see> with <see cref="StringComparison.Ordinal">StringComparison.Ordinal</see>.
+		/// </summary>
+#endif
 		public static bool ContainsOrdinal(this string source, char value) =>
 #if NETSTANDARD2_0
 			source.Contains(value);
@@ -89,10 +94,15 @@ namespace Faithlife.Utility
 			source.Contains(value, StringComparison.Ordinal);
 #endif
 
+#if NETSTANDARD2_0
 		/// <summary>
-		/// Calls <see cref="string.Contains(string, StringComparison)">string.Contains</see> with
-		/// <see cref="StringComparison.Ordinal">StringComparison.Ordinal</see>.
+		/// Calls string.Contains with StringComparison.Ordinal.
 		/// </summary>
+#else
+		/// <summary>
+		/// Calls <see cref="string.Contains(char, StringComparison)">string.Contains</see> with <see cref="StringComparison.Ordinal">StringComparison.Ordinal</see>.
+		/// </summary>
+#endif
 		public static bool ContainsOrdinal(this string source, string value) =>
 #if NETSTANDARD2_0
 			source.Contains(value);

--- a/src/Faithlife.Utility/StringUtility.cs
+++ b/src/Faithlife.Utility/StringUtility.cs
@@ -904,6 +904,12 @@ namespace Faithlife.Utility
 			source.Contains(value, StringComparison.Ordinal);
 #endif
 
+		public static bool ContainsAllOrdinal(this string source, IEnumerable<string> values) =>
+			values.All(source.ContainsOrdinal);
+
+		public static bool ContainsAllOrdinal(this string source, params string[] values) =>
+			source.ContainsAllOrdinal(values.AsEnumerable());
+
 		private sealed class CompressingTextWriter : TextWriter
 		{
 			public CompressingTextWriter(Stream stream, Ownership ownership)

--- a/src/Faithlife.Utility/StringUtility.cs
+++ b/src/Faithlife.Utility/StringUtility.cs
@@ -910,6 +910,11 @@ namespace Faithlife.Utility
 		public static bool ContainsAllOrdinal(this string source, params string[] values) =>
 			source.ContainsAllOrdinal(values.AsEnumerable());
 
+#if !NETSTANDARD2_0
+		public static bool ContainsAll(this string source, IEnumerable<string> values, StringComparison comparisonType) =>
+			values.All(value => source.Contains(value, comparisonType));
+#endif
+
 		private sealed class CompressingTextWriter : TextWriter
 		{
 			public CompressingTextWriter(Stream stream, Ownership ownership)

--- a/src/Faithlife.Utility/StringUtility.cs
+++ b/src/Faithlife.Utility/StringUtility.cs
@@ -78,6 +78,9 @@ namespace Faithlife.Utility
 #endif
 		}
 
+		/// <summary>
+		/// Calls string.<see cref="string.Contains(char, StringComparison)"/> with StringComparison.<see cref="StringComparison.Ordinal"/>.
+		/// </summary>
 		public static bool ContainsOrdinal(this string source, char value) =>
 #if NETSTANDARD2_0
 			source.Contains(value);
@@ -85,6 +88,9 @@ namespace Faithlife.Utility
 			source.Contains(value, StringComparison.Ordinal);
 #endif
 
+		/// <summary>
+		/// Calls string.<see cref="string.Contains(string, StringComparison)"/> with StringComparison.<see cref="StringComparison.Ordinal"/>.
+		/// </summary>
 		public static bool ContainsOrdinal(this string source, string value) =>
 #if NETSTANDARD2_0
 			source.Contains(value);

--- a/src/Faithlife.Utility/StringUtility.cs
+++ b/src/Faithlife.Utility/StringUtility.cs
@@ -78,6 +78,20 @@ namespace Faithlife.Utility
 #endif
 		}
 
+		public static bool ContainsOrdinal(this string source, char value) =>
+#if NETSTANDARD2_0
+			source.Contains(value);
+#else
+			source.Contains(value, StringComparison.Ordinal);
+#endif
+
+		public static bool ContainsOrdinal(this string source, string value) =>
+#if NETSTANDARD2_0
+			source.Contains(value);
+#else
+			source.Contains(value, StringComparison.Ordinal);
+#endif
+
 		/// <summary>
 		/// Compares two specified <see cref="string"/> objects by comparing successive Unicode code points. This method differs from
 		/// <see cref="string.CompareOrdinal(string, string)"/> in that this method considers supplementary characters (which are
@@ -889,20 +903,6 @@ namespace Faithlife.Utility
 		/// <returns>The TextReader.</returns>
 		public static TextReader CreateDecompressingTextReader(Stream stream, Ownership ownership) =>
 			new DecompressingTextReader(stream, ownership);
-
-		public static bool ContainsOrdinal(this string source, char value) =>
-#if NETSTANDARD2_0
-			source.Contains(value);
-#else
-			source.Contains(value, StringComparison.Ordinal);
-#endif
-
-		public static bool ContainsOrdinal(this string source, string value) =>
-#if NETSTANDARD2_0
-			source.Contains(value);
-#else
-			source.Contains(value, StringComparison.Ordinal);
-#endif
 
 		private sealed class CompressingTextWriter : TextWriter
 		{

--- a/src/Faithlife.Utility/StringUtility.cs
+++ b/src/Faithlife.Utility/StringUtility.cs
@@ -890,6 +890,20 @@ namespace Faithlife.Utility
 		public static TextReader CreateDecompressingTextReader(Stream stream, Ownership ownership) =>
 			new DecompressingTextReader(stream, ownership);
 
+		public static bool ContainsOrdinal(this string source, char value) =>
+#if NETSTANDARD2_0
+			source.Contains(value);
+#else
+			source.Contains(value, StringComparison.Ordinal);
+#endif
+
+		public static bool ContainsOrdinal(this string source, string value) =>
+#if NETSTANDARD2_0
+			source.Contains(value);
+#else
+			source.Contains(value, StringComparison.Ordinal);
+#endif
+
 		private sealed class CompressingTextWriter : TextWriter
 		{
 			public CompressingTextWriter(Stream stream, Ownership ownership)

--- a/tests/Faithlife.Utility.Tests/StringUtilityTests.cs
+++ b/tests/Faithlife.Utility.Tests/StringUtilityTests.cs
@@ -33,6 +33,8 @@ namespace Faithlife.Utility.Tests
 			Assert.IsFalse("abc".StartsWithOrdinal("bc"));
 			Assert.IsFalse("abc".EndsWithOrdinal("ab"));
 			Assert.IsTrue("abc".EndsWithOrdinal("bc"));
+			Assert.IsTrue("abc".ContainsOrdinal("bc"));
+			Assert.IsFalse("abc".ContainsOrdinal("cd"));
 			Assert.AreEqual(1, "abcabc".IndexOfOrdinal("bc"));
 			Assert.AreEqual(-1, "abcabc".IndexOfOrdinal("ba"));
 			Assert.AreEqual(4, "abcabc".IndexOfOrdinal("bc", 2));


### PR DESCRIPTION
Would the following new `string` extensions be desirable?

```c#
bool ContainsOrdinal(this string source, char value);
bool ContainsOrdinal(this string source, string value);
bool ContainsAllOrdinal(this string source, IEnumerable<string> values);
bool ContainsAllOrdinal(this string source, params string[] values);
bool ContainsAll(this string source, IEnumerable<string> values, StringComparison comparisonType);
```

Specifically, I found myself wanting to use a `bool ContainsAllOrdinal(this string source, params string[] values)` in my work today.

I'll add a few tests if these are approved in general; I just wanted to make sure they're wanted before I take the time.